### PR TITLE
Revision

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,24 +2,26 @@
 
 pkgname=jade
 pkgver=1.1.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Scriptable backend & TUI Installer for Crystal Linux"
-license=('GPLv3')
-arch=('x86_64')
-url="https://github.com/crystal-linux/$pkgname"
-license=('GPL')
-source=("jade-$pkgver-$pkgrel::git+$url#tag=v$pkgver")
+arch=(x86_64)
+url="https://github.com/crystal-linux/jade"
+license=(GPL3)
+depends=(parted)
+makedepends=(git cargo)
+source=("git+$url#tag=v$pkgver")
 sha256sums=('SKIP')
-depends=('parted')
-makedepends=('cargo')
+
+prepare() {
+    cd "${srcdir}/${pkgname}"
+    cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+}
 
 build() {
-    cd "$srcdir/$pkgname-$pkgver-$pkgrel"
-    cargo build --release
+    cd "${srcdir}/${pkgname}"
+    cargo build --release --frozen
 }
 
 package() {
-    mkdir -p $pkgdir/usr/bin
-    chmod +x ${srcdir}/$pkgname-$pkgver-$pkgrel/target/release/jade
-    install --mode +x ${srcdir}/$pkgname-$pkgver-$pkgrel/target/release/jade  $pkgdir/usr/bin/.
+    install -Dm755 "${srcdir}/$pkgname/target/release/jade" -t "${pkgdir}/usr/bin/"
 }


### PR DESCRIPTION
Hello, some changes are needed, some are aesthetics, you may want to set your style  as suggested by @Antiz96 (i.e. always using `${pkgname}` over `$pkgname`) so you may like or not some changes I've made (hope I've explained them well enough)

* Follow more Rust packaging guidelines in prepare() and build(), https://wiki.archlinux.org/title/Rust_package_guidelines#Prepare, also used in some others of yours pkgbuild
* Double license field, license typing is GPL3 not GPLv3 (see licenses package, analyze packages with namcap), GPL mean GPL version 2
* added missing `git` makedepends, you're welcome to build in a clean chroot for ensuring needed depends and makedepends are met, for convenience using `extra-x86_64-build` from `devtools` package https://wiki.archlinux.org/title/DeveloperWiki:Building_in_a_clean_chroot (I hope over time you will build all packages in clean chroot, sign them and set packager= field like Arch does)
* About source=(), renaming to the same name (jade to jade) is pointless, $pkgrel don't have to be in source=() (i.e. on rebuilds you rebuild the same version, no need to change source), renaming git sources to $pkgname-$pkgver is detrimeral because they are completely downloaded each time; instead make them reusable and use in general a common source destination (SRCDEST= in makepkg.conf)
* made package() 1 line instead of 3
* More strict following of Arch example pkgbuild for fields order
* While it is often used; single or double quoting in arch=() license=() depends=() makedepends=() depends=() is pointless to pkgbuild functioning,
except when needed [i.e. optdepends=('gst-libav: additional codecs') license=('custom:WTFPL') license=('custom:corp EULA')], personally stopped using them when dealing with pkgbuilds with 40+ depends/makedepends and adjusting them by copy-pasting
* Removed variable from url=, another personal choice, when you're in pkgbuild text files variables aren't resolved and I find it annoying when I need to copy from pkgbuild and past to browser to check urls (in the past I used variables more often)